### PR TITLE
feat: 修改page item 和 a标签dom结构，方便查看内部元素

### DIFF
--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -21,12 +21,13 @@ const position = (page: Page) => {
 <template>
   <div class="pages main-content">
     <div class="post-entry mr-10 ml-10" v-for="page of pages">
-      <PageListItem
-        :position="position(page)"
-        :showCover="showCover(page)"
-        :page="page"
-      />
-      <a class="entry-link" :aria-label="page.title" :href="page.url"></a>
+      <a :aria-label="page.title" :href="page.url">
+        <PageListItem
+          :position="position(page)"
+          :showCover="showCover(page)"
+          :page="page"
+        />
+      </a>
     </div>
   </div>
 </template>


### PR DESCRIPTION
之前的是通过一个平级的a标签定位在整个page item之上，查看element的时候不能直接选中内部元素